### PR TITLE
add memory safety tests

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -313,6 +313,40 @@ mod tests {
     use super::*;
     use crate::status::Status;
 
+     #[test]
+    fn call_solve_without_problem() {
+        Model::new().solve();
+    }
+
+    #[test]
+    fn solution_without_problem() {
+        let mut model = Model::new();
+        let sol = model.get_best_sol();
+        sol.get_obj_val();
+    }
+
+    #[test]
+    fn drop_problem_before_solution() {
+        let sol = {
+            let mut model = Model::new();
+            model.hide_output();
+            model.include_default_plugins();
+            model.read_prob("data/test/simple.lp");
+            model.solve();
+            model.get_best_sol()
+        };
+        assert_eq!(sol.get_obj_val(), 200.);
+    }
+
+    #[test]
+    fn drop_variable_after_problem() {
+        let mut model = Model::new();
+        let var_id = model.add_var(0., 0., 0., "", VarType::Binary);
+        let var = model.get_var(var_id).unwrap();
+        drop(model);
+        drop(var);
+    }
+
     #[test]
     fn solve_from_lp_file() -> Result<(), Retcode> {
         let mut model = Model::new()?;

--- a/src/model.rs
+++ b/src/model.rs
@@ -315,12 +315,12 @@ mod tests {
 
      #[test]
     fn call_solve_without_problem() {
-        Model::new().solve();
+        assert!(Model::new().unwrap().solve().is_err());
     }
 
     #[test]
     fn solution_without_problem() {
-        let mut model = Model::new();
+        let mut model = Model::new().unwrap();
         let sol = model.get_best_sol();
         sol.get_obj_val();
     }
@@ -328,11 +328,11 @@ mod tests {
     #[test]
     fn drop_problem_before_solution() {
         let sol = {
-            let mut model = Model::new();
-            model.hide_output();
-            model.include_default_plugins();
-            model.read_prob("data/test/simple.lp");
-            model.solve();
+            let mut model = Model::new().unwrap();
+            model.hide_output().unwrap();
+            model.include_default_plugins().unwrap();
+            model.read_prob("data/test/simple.lp").unwrap();
+            model.solve().unwrap();
             model.get_best_sol()
         };
         assert_eq!(sol.get_obj_val(), 200.);
@@ -340,8 +340,8 @@ mod tests {
 
     #[test]
     fn drop_variable_after_problem() {
-        let mut model = Model::new();
-        let var_id = model.add_var(0., 0., 0., "", VarType::Binary);
+        let mut model = Model::new().unwrap();
+        let var_id = model.add_var(0., 0., 0., "", VarType::Binary).unwrap();
         let var = model.get_var(var_id).unwrap();
         drop(model);
         drop(var);


### PR DESCRIPTION
These tests show a few examples of how the interface currently exposed is unsafe. This illustrates #8 

After spending some time looking at the code, it looks like you tried to model the C interface very closely, which is not a good thing. 

An advice would be to spend some time reading very carefully the C interface documentation, taking special care about preconditions and postconditions for every method, when memory should be allocated and released, and trying to come up with a rust interface that [makes illegal states irrepresentable](https://ybogomolov.me/making-illegal-states-unrepresentable/).